### PR TITLE
Terms & privacy policy update

### DIFF
--- a/about.html
+++ b/about.html
@@ -77,15 +77,3 @@ title: About
 
 <h3>Our sponsors</h3>
 <p>{% include funding.html %}</p>
-
-<h3>Policies</h3>
-<ul>
-  <li>
-    <a href="{{ site.baseurl }}/terms-of-use/">AiiDAlab Terms of Use</a>
-  </li>
-  <li>
-    <a href="{{ site.baseurl }}/privacy-policy/"
-      >AiiDAlab Privacy Policy (Personal Data Protection)</a
-    >
-  </li>
-</ul>

--- a/deployments.html
+++ b/deployments.html
@@ -10,6 +10,7 @@ deployments_table:
       - text: Open to all researchers affiliated with <a href="https://www.materialscloud.org/home#partners">Materials Cloud partners</a>
         highlight: true
       - text: Hosted at the <a href="https://www.cscs.ch/">Swiss National Supercomputing Centre (CSCS)</a>
+      - text: Policies <br> <a href="{{ site.baseurl }}/terms-of-use/">Terms of Use</a><br><a href="{{ site.baseurl }}/privacy-policy/">Privacy Policy (Personal Data Protection)</a>
       - text: Sponsored by a <a href="https://prace-ri.eu/">PRACE</a>-<a href="https://fenix-ri.eu/">FENIX</a> grant
       - images:
           - src: images/endorsers/prace.png

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -3,7 +3,10 @@ title: Privacy Policy (Personal Data Protection)
 ---
 
 <div>
-  <p>AiiDAlab Privacy Policy (Personal Data Protection) v1.1, December 2023</p>
+  <p>
+    AiiDAlab Materials Cloud Deployment Privacy Policy (Personal Data
+    Protection) v1.2, 2023
+  </p>
 
   <h3>Scope and Definitions</h3>
   <p>
@@ -23,8 +26,8 @@ title: Privacy Policy (Personal Data Protection)
     For the personal data of the Users, which are collected by AiiDAlab for the
     User's account and the operation of the Services by AiiDAlab:
     <a href="mailto:aiidalab@materialscloud.org">aiidalab@materialscloud.org</a>
-    on behalf of Ecole Polytechnique F&eacute;d&eacute;rale de Lausanne, Station
-    1, 1015 Lausanne, Switzerland.
+    on behalf of Paul Scherrer Institute, Forschungsstrasse 111, 5303 Villigen,
+    Switzerland.
   </p>
 
   <p>
@@ -64,12 +67,12 @@ title: Privacy Policy (Personal Data Protection)
 
   <h4>Place</h4>
   <p>
-    AiiDAlab computing infrastructure is hosted at the CESNET e-infrastructure
-    for science, research and education (CESNET) in Prague, Czech Republic;
-    hence, your personal data processed by AiiDAlab is stored at said place. If
-    you access to the Services from outside of the Czech Republic, you
-    understand that your data is then transferred abroad. For further
-    information, please contact the data Controller as indicated above.
+    AiiDAlab computing infrastructure is hosted at the Swiss National
+    Supercomputing Centre (CSCS) in Lugano, Switzerland; hence, your personal
+    data processed by AiiDAlab is stored at said place. If you access to the
+    Services from outside of the Switzerland, you understand that your data is
+    then transferred abroad. For further information, please contact the data
+    Controller as indicated above.
   </p>
 
   <h4>Retention time</h4>
@@ -114,7 +117,7 @@ title: Privacy Policy (Personal Data Protection)
     You warrant that if you post on the Website or collect, handle, store,
     transfer or otherwise process any personal data in connection with the
     Services, you will do so in compliance with all applicable laws and
-    regulations. You agree to indemnify and hold EPFL, its partners and any
+    regulations. You agree to indemnify and hold PSI, its partners and any
     sub-contractors, harmless from and against any and all claims, liabilities,
     and expenses, including attorneys' fees, arising out of your posting of any
     personal data on the Website or your processing of any personal data in

--- a/terms-of-use.html
+++ b/terms-of-use.html
@@ -3,11 +3,11 @@ title: Terms of Use
 ---
 
 <div>
-  <p>AiiDAlab Terms of Use v1.1, 2023</p>
+  <p>AiiDAlab Terms of Use v1.2, 2023</p>
 
   <h3>1. Scope</h3>
   <p>
-    These Terms of Use are a legally binding agreement among EPFL and you and
+    These Terms of Use are a legally binding agreement among PSI and you and
     shall apply to your use of the AiiDAlab services.
   </p>
 
@@ -19,12 +19,8 @@ title: Terms of Use
       chemistry and materials science.
     </li>
     <li>
-      &ldquo;EPFL&rdquo; means Ecole Polytechnique F&eacute;d&eacute;rale de
-      Lausanne, a Swiss public university, which is operating the Services in
-      its quality as the Leading House of the MARVEL National Centre of
-      Competence in Research (NCCR), of the swissuniversities P-5 project
-      "Materials Cloud" and as partner of the H2020 European Centre of
-      Excellence "MaX".
+      &ldquo;PSI&rdquo; means Paul Scherrer Institute, a Swiss research
+      institute for natural and engineering sciences.
     </li>
     <li>
       &ldquo;Terms of Use&rdquo; mean the provisions contained in the present
@@ -34,7 +30,7 @@ title: Terms of Use
     </li>
     <li>
       The &ldquo;Services&rdquo; means the applications, software and services
-      provided by EPFL through AiiDAlab.
+      provided by PSI through AiiDAlab.
     </li>
     <li>
       The &ldquo;Website&rdquo; means the AiiDAlab website and all content and
@@ -104,11 +100,11 @@ located on ould.org -->. Your account will be then activated. You hereby warrant
 
   <h4>3.2 Your Personal Data</h4>
   <p>
-    EPFL will use your personal data provided to AiiDAlab only for the purpose
-    of operating the Website and the Services; you hereby agree to such
-    processing. EPFL shall process and handle said personal data in compliance
-    with the applicable laws and regulations and in accordance with AiiDAlab
-    Privacy Policy.
+    PSI will use your personal data provided to AiiDAlab only for the purpose of
+    operating the Website and the Services; you hereby agree to such processing.
+    PSI shall process and handle said personal data in compliance with the
+    applicable laws and regulations and in accordance with AiiDAlab Privacy
+    Policy.
   </p>
 
   <h4>3.3 User Responsibility for Account Security</h4>
@@ -118,13 +114,13 @@ located on ould.org -->. Your account will be then activated. You hereby warrant
     protect that information from access by others.
   </p>
   <p>
-    For the avoidance of doubt, EPFL shall in no case be liable for any loss or
+    For the avoidance of doubt, PSI shall in no case be liable for any loss or
     damage arising from your failure to comply with your security obligations.
   </p>
   <p>
-    You will promptly notify EPFL through AiiDAlab Website if you become aware
-    of any unauthorized access to AiiDAlab Services through your account,
-    including any unauthorized use of your password or account.
+    You will promptly notify PSI through AiiDAlab Website if you become aware of
+    any unauthorized access to AiiDAlab Services through your account, including
+    any unauthorized use of your password or account.
   </p>
 
   <h4>3.4 User's other Responsibilities and Liability</h4>
@@ -157,10 +153,6 @@ located on ould.org -->. Your account will be then activated. You hereby warrant
   </ul>
   <p>
     You shall abide to the
-    <a href="https://polylex.epfl.ch/page-60179-en.html" target="_blank"
-      >EPFL Directive on the Use of EPFL electronic infrastructure</a
-    >
-    and the
     <a
       href="https://rechtssammlung.sp.ethz.ch/Dokumente/203.21en.pdf"
       target="_blank"
@@ -185,7 +177,7 @@ located on ould.org -->. Your account will be then activated. You hereby warrant
       your authorization, or by uploading content containing malware;
     </li>
     <li>
-      impersonate any person or entity, including any of EPFL employees or
+      impersonate any person or entity, including any of PSI employees or
       representatives, including through false association with AiiDAlab, or by
       fraudulently misrepresenting your identity or site's purpose.
     </li>
@@ -194,7 +186,7 @@ located on ould.org -->. Your account will be then activated. You hereby warrant
   <h5>3.4.3 No Abuse of the Services</h5>
   <p>
     You shall not reproduce, copy, sell, resell or exploit any portion of the
-    Services or the Website without EPFL’s express written permission.
+    Services or the Website without PSI’s express written permission.
   </p>
 
   <h5>3.4.4 No Scraping</h5>
@@ -231,40 +223,39 @@ located on ould.org -->. Your account will be then activated. You hereby warrant
   <p>
     Advertising Content, like all Content, must not violate the law or these
     Terms of Use, for example through excessive bulk activity such as spamming.
-    EPFL reserves the right to remove any advertisements that, in EPFL's sole
+    PSI reserves the right to remove any advertisements that, in PSI's sole
     discretion, violate the Terms of Use or the law.
   </p>
 
   <h5>3.4.7 Liability</h5>
   <p>
     You and/or the company or entity on behalf of which you use your account
-    shall be liable to EPFL, the other Users and any others for any damages or
+    shall be liable to PSI, the other Users and any others for any damages or
     claims arising from your unlawful use of the Services or the Website and for
-    any violation of these Terms of Use. You shall indemnify and hold EPFL, its
+    any violation of these Terms of Use. You shall indemnify and hold PSI, its
     partners and any sub-contractor harmless against any claims and damages
     arising from your unlawful use of the Services or the Website or any
     violation of these Terms of Use.
   </p>
 
   <h3>4. User-Uploaded Content</h3>
-  <h4>4.1 User's Responsibility and EPFL's Right to Remove</h4>
+  <h4>4.1 User's Responsibility and PSI's Right to Remove</h4>
   <p>
     You may create and/or upload Content while using the Services. You are
     solely responsible for the content of, and for any harm resulting from, any
     User-Uploaded Content (including any Third Party's Content) that you post,
     upload, link to or otherwise make available via the Services, regardless of
-    the form of that content. EPFL is not responsible for any public display or
+    the form of that content. PSI is not responsible for any public display or
     misuse of your User-Uploaded Content.
   </p>
   <p>
-    EPFL does not pre-screen User-Uploaded Content, but EPFL has the right
-    (though not the obligation) to refuse or remove any User-Uploaded Content
-    that EPFL determines, in its sole discretion, to violate the Terms of Use or
-    any law.
+    PSI does not pre-screen User-Uploaded Content, but PSI has the right (though
+    not the obligation) to refuse or remove any User-Uploaded Content that PSI
+    determines, in its sole discretion, to violate the Terms of Use or any law.
   </p>
   <p>
-    You agree that EPFL may remove any User-Uploaded Content that EPFL in its
-    sole discretion determines to be inappropriate.
+    You agree that PSI may remove any User-Uploaded Content that PSI in its sole
+    discretion determines to be inappropriate.
   </p>
 
   <h4>4.2 Ownership of Content, Right to Post, and License Grants</h4>
@@ -273,13 +264,13 @@ located on ould.org -->. Your account will be then activated. You hereby warrant
     up-load on AiiDAlab.
   </p>
   <p>
-    Because you retain ownership of and responsibility for Your Content, EPFL
-    needs you to grant EPFL, and the other AiiDAlab Users, certain legal
+    Because you retain ownership of and responsibility for Your Content, PSI
+    needs you to grant PSI, and the other AiiDAlab Users, certain legal
     permissions, listed in Sections 4.4 to 4.6. These license grants apply to
     Your Content. You understand that you will not receive any payment for any
     of the rights granted in Sections 4.4 to 4.6. The licenses you grant
     hereunder are perpetual. If you upload Content that already comes with a
-    license granting EPFL the permissions EPFL needs to run the Services, no
+    license granting PSI the permissions PSI needs to run the Services, no
     additional license is required.
   </p>
 
@@ -293,16 +284,16 @@ located on ould.org -->. Your account will be then activated. You hereby warrant
     grant the licenses listed in Sections 4.4 to 4.6.
   </p>
   <p>
-    You shall indemnify and hold EPFL, its partners and any sub-contractor
+    You shall indemnify and hold PSI, its partners and any sub-contractor
     harmless against any claims and damages arising from your up-loading of any
     Third Party's Content.
   </p>
 
-  <h4>4.4 License Grant to EPFL</h4>
+  <h4>4.4 License Grant to PSI</h4>
   <p>
-    EPFL needs the legal right to do things such as host Your Content and any
-    Third Party's Content you up-load. You hereby grant EPFL, its service
-    providers or sub-contractors and EPFL legal successors the right to use,
+    PSI needs the legal right to do things such as host Your Content and any
+    Third Party's Content you up-load. You hereby grant PSI, its service
+    providers or sub-contractors and PSI legal successors the right to use,
     store, parse, and display Your Content and any Third Party's Content you
     up-load, and make incidental copies thereof as necessary to render the
     Website and provide the Services. This includes the right to do things like
@@ -329,13 +320,13 @@ located on ould.org -->. Your account will be then activated. You hereby warrant
     part of the Services, including the rights of integrity and attribution
     unless otherwise provided in any license you attached to Your Content or in
     any license attached to another User's Content (see Section 4.5). However,
-    you waive these rights and agree not to assert them against EPFL, to enable
-    EPFL to reasonably exercise the rights granted in Section 4, but not
+    you waive these rights and agree not to assert them against PSI, to enable
+    PSI to reasonably exercise the rights granted in Section 4, but not
     otherwise.
   </p>
   <p>
     To the extent this Section is not enforceable by applicable local law, you
-    grant EPFL the rights EPFL needs to use Your Content without attribution and
+    grant PSI the rights PSI needs to use Your Content without attribution and
     to make reasonable adaptations of Your Content as necessary to render the
     Website and provide the Services.
   </p>
@@ -347,19 +338,19 @@ located on ould.org -->. Your account will be then activated. You hereby warrant
     or the Public.
   </p>
   <p>
-    EPFL will use reasonable efforts to protect the contents of private sections
-    from unauthorized use, access, or disclosure. However, EPFL extends no
+    PSI will use reasonable efforts to protect the contents of private sections
+    from unauthorized use, access, or disclosure. However, PSI extends no
     warranties as to any unauthorized use, access or disclosure of such content
     by third parties.
   </p>
   <p>
-    EPFL employees, or employees of EPFL sub-contracting entity operating the
+    PSI employees, or employees of PSI sub-contracting entity operating the
     supercomputing infrastructure used for some of the Services, may only access
     the content of your private areas in the following situations:
   </p>
   <ul>
     <li>
-      with your consent, for support reasons. If EPFL (or the abovementioned
+      with your consent, for support reasons. If PSI (or the abovementioned
       sub-contracting entity) accesses a private repository for support reasons,
       we will only do so with the User's consent and knowledge; or
     </li>
@@ -367,32 +358,31 @@ located on ould.org -->. Your account will be then activated. You hereby warrant
     <li>when accessing it for backup or service maintenance reasons.</li>
   </ul>
   <p>
-    If EPFL has reason to believe the contents of a private area are in
-    violation of the law or of these Terms of Use, EPFL has the right to access,
-    review, and remove them. Additionally, EPFL may be compelled by law to
-    disclose the contents of your private repositories.
+    If PSI has reason to believe the contents of a private area are in violation
+    of the law or of these Terms of Use, PSI has the right to access, review,
+    and remove them. Additionally, PSI may be compelled by law to disclose the
+    contents of your private repositories.
   </p>
 
   <h3>5. Intellectual Property Notice</h3>
-  <h4>5.1. EPFL's Rights to Content</h4>
+  <h4>5.1. PSI's Rights to Content</h4>
   <p>
-    EPFL and EPFL's partners, licensors, vendors, agents, and/or content
-    providers retain ownership of all intellectual property rights of any kind
-    related to the Website and Services. EPFL reserves all rights that are not
-    expressly granted to you under this Agreement or by law. The look and feel
-    of the Website and Services is copyright of Ecole Polytechnique
-    F&eacute;d&eacute;rale de Lausanne, Switzerland (for the account of the
-    MARVEL NCCR) or its respective licensors, vendors, agents and/or content
-    providers. You may not duplicate, copy, or reuse any portion of the
-    HTML/CSS, Javascript, or visual design elements or concepts without express
-    written permission from EPFL.
+    PSI and PSI's partners, licensors, vendors, agents, and/or content providers
+    retain ownership of all intellectual property rights of any kind related to
+    the Website and Services. PSI reserves all rights that are not expressly
+    granted to you under this Agreement or by law. The look and feel of the
+    Website and Services is copyright of Paul Scherrer Institute, Switzerland
+    (for the account of the MARVEL NCCR) or its respective licensors, vendors,
+    agents and/or content providers. You may not duplicate, copy, or reuse any
+    portion of the HTML/CSS, Javascript, or visual design elements or concepts
+    without express written permission from PSI.
   </p>
 
-  <h4>5.2. EPFL Trademarks and Logos</h4>
+  <h4>5.2. PSI Trademarks and Logos</h4>
   <p>
-    If you'd like to use EPFL's trademarks, logos or names, including
+    If you'd like to use PSI's trademarks, logos or names, including
     &ldquo;AiiDAlab&rdquo; name and logos, you must first obtain the written
-    permission of EPFL.
+    permission of PSI.
   </p>
 
   <h4>5.3. License to this Agreement</h4>
@@ -412,8 +402,8 @@ located on ould.org -->. Your account will be then activated. You hereby warrant
   </p>
   <p>We will terminate the accounts of repeat infringers of this Section.</p>
   <p>
-    As stated in Sections 4.1 and 4.7, EPFL reserves the right to remove any of
-    your Uploaded Content that EPFL determines to infringe upon other User's
+    As stated in Sections 4.1 and 4.7, PSI reserves the right to remove any of
+    your Uploaded Content that PSI determines to infringe upon other User's
     copyrights (or third party's copyrights).
   </p>
 
@@ -466,9 +456,9 @@ located on ould.org -->. Your account will be then activated. You hereby warrant
 
   <h4>8.2. Upon Cancellation</h4>
   <p>
-    EPFL will retain and use your information as necessary to comply with its
+    PSI will retain and use your information as necessary to comply with its
     legal obligations, resolve disputes, and enforce agreements, but barring
-    legal requirements, EPFL will delete your full profile and the Content in
+    legal requirements, PSI will delete your full profile and the Content in
     your Private Area if any, within 90 days of cancellation or termination;
     however, though some information may remain in backups. This information
     cannot be recovered once your account is cancelled. Since the aim of
@@ -478,11 +468,11 @@ located on ould.org -->. Your account will be then activated. You hereby warrant
     these Terms of Use).
   </p>
 
-  <h4>8.3. EPFL Termination Rights</h4>
+  <h4>8.3. PSI Termination Rights</h4>
   <p>
-    EPFL has the right to suspend or terminate your access to all or any part of
+    PSI has the right to suspend or terminate your access to all or any part of
     the Website or Services at any time. You hereby waive any claim, demands and
-    damages against EPFL (and the MARVEL members) and its service providers in
+    damages against PSI (and the MARVEL members) and its service providers in
     case of such a termination.
   </p>
 
@@ -497,27 +487,26 @@ located on ould.org -->. Your account will be then activated. You hereby warrant
   <h3>9. Communications with AiiDAlab</h3>
   <h4>9.1. Electronic Communication Required</h4>
   <p>
-    For contractual purposes, you (1) consent to receive communications from
-    EPFL in an electronic form via the email address you have submitted or via
-    the Services; and (2) agree that the Terms of Use and any agreements,
-    notices, disclosures, and other communications that EPFL provides in
-    connection with AiiDAlab to you electronically satisfy any legal requirement
-    that those communications would satisfy if they were on paper. This section
-    does not affect any non-waivable rights by law.
+    For contractual purposes, you (1) consent to receive communications from PSI
+    in an electronic form via the email address you have submitted or via the
+    Services; and (2) agree that the Terms of Use and any agreements, notices,
+    disclosures, and other communications that PSI provides in connection with
+    AiiDAlab to you electronically satisfy any legal requirement that those
+    communications would satisfy if they were on paper. This section does not
+    affect any non-waivable rights by law.
   </p>
 
   <h4>9.2. Legal Notice to AiiDAlab</h4>
   <p>
-    Legal notice to EPFL must be in writing and served to: Ecole Polytechnique
-    F&eacute;d&eacute;rale de Lausanne, Centre Est, Station 1, 1015 Lausanne,
-    Switzerland or to
+    Legal notice to PSI must be in writing and served to: Paul Scherrer
+    Institute, Forschungsstrasse 111, 5303 Villigen, Switzerland or to
     <a href="mailto:aiidalab@materialscloud.org">aiidalab@materialscloud.org</a
     >.
   </p>
 
   <h4>9.3. No Phone Support</h4>
   <p>
-    EPFL only offers for AiiDAlab support via email, in-Services communications,
+    PSI only offers for AiiDAlab support via email, in-Services communications,
     and electronic messages. There is no telephone support.
   </p>
 
@@ -525,11 +514,10 @@ located on ould.org -->. Your account will be then activated. You hereby warrant
   <p>
     AiiDAlab and its subcontractors provide the Website and the Services
     &ldquo;as is&rdquo; and &ldquo;as available,&rdquo; without warranty of any
-    kind. Without limiting this, EPFL expressly disclaims all warranties,
-    whether express, implied or statutory, regarding the Website and the
-    Services including without limitation any warranty of merchantability,
-    fitness for a particular purpose, title, security, accuracy and
-    non-infringement.
+    kind. Without limiting this, PSI expressly disclaims all warranties, whether
+    express, implied or statutory, regarding the Website and the Services
+    including without limitation any warranty of merchantability, fitness for a
+    particular purpose, title, security, accuracy and non-infringement.
   </p>
   <p>
     AiiDAlab and its subcontractor do not warrant that the Services will meet
@@ -545,7 +533,7 @@ located on ould.org -->. Your account will be then activated. You hereby warrant
 
   <h3>11. Limitation of Liability</h3>
   <p>
-    You understand and agree that EPFL (and its subcontractors) will not be
+    You understand and agree that PSI (and its subcontractors) will not be
     liable to you or any third party for any loss of profits, use, goodwill, or
     data, or for any incidental, indirect, special, consequential or exemplary
     damages, however arising, that result from
@@ -572,12 +560,12 @@ located on ould.org -->. Your account will be then activated. You hereby warrant
     <li>any other matter relating to the Services.</li>
   </ul>
   <p>
-    EPFL and its subcontractors liability is limited whether or not we have been
+    PSI and its subcontractors liability is limited whether or not we have been
     informed of the possibility of such damages, and even if a remedy set forth
     in these Terms of Use is found to have failed of its essential purpose.
-    Should EPFL liability limitations not be enforceable under imperative law,
-    then the maximum liability of EPFL in connection with the Services or the
-    use of the Website shall be limited to the smaller of the amount paid by the
+    Should PSI liability limitations not be enforceable under imperative law,
+    then the maximum liability of PSI in connection with the Services or the use
+    of the Website shall be limited to the smaller of the amount paid by the
     User over the last six months or five hundred Swiss francs.
   </p>
 
@@ -589,7 +577,7 @@ located on ould.org -->. Your account will be then activated. You hereby warrant
     arising out of or in any way connected with such disputes.
   </p>
   <p>
-    You agree to indemnify and hold EPFL, its partners and any sub-contractor,
+    You agree to indemnify and hold PSI, its partners and any sub-contractor,
     harmless from and against any and all claims, liabilities, and expenses,
     including attorneys' fees, arising out of your use of the Website and the
     Services, including but not limited to your violation of the Terms of Use.
@@ -597,7 +585,7 @@ located on ould.org -->. Your account will be then activated. You hereby warrant
 
   <h3>13. Changes to These Terms of Use</h3>
   <p>
-    EPFL reserves the right, at its sole discretion, to amend these Terms of Use
+    PSI reserves the right, at its sole discretion, to amend these Terms of Use
     at any time and will update them in the event of any such amendments. We
     will notify the Users of material changes to these Terms of Use, such as
     price changes, at least 30 days prior to the change taking effect by posting
@@ -616,7 +604,7 @@ located on ould.org -->. Your account will be then activated. You hereby warrant
   <h3>15. Miscellaneous</h3>
   <h4>15.1. Governing Law &mdash; Place of Jurisdiction</h4>
   <p>
-    These Terms of Use between you and EPFL, any access to or use of the Website
+    These Terms of Use between you and PSI, any access to or use of the Website
     or the Services, and any claims raised in connection with the Terms of Use
     or the Website or the Services, are governed by Swiss law, without regard to
     conflict of law provisions. You agree to submit to the exclusive
@@ -626,11 +614,11 @@ located on ould.org -->. Your account will be then activated. You hereby warrant
 
   <h4>15.2. Non-Assignability</h4>
   <p>
-    EPFL may assign or delegate these Terms of Use and/or the AiiDAlab Privacy
+    PSI may assign or delegate these Terms of Use and/or the AiiDAlab Privacy
     Policy in whole or in part, to any person or entity at any time with or
     without your consent, including the license grants in Section 4. You may not
     assign or delegate any rights or obligations under these Terms of Use
-    without EPFL prior written consent, and any unauthorized assignment and
+    without PSI prior written consent, and any unauthorized assignment and
     delegation by you is void.
   </p>
 
@@ -640,23 +628,23 @@ located on ould.org -->. Your account will be then activated. You hereby warrant
     portion will be construed to reflect the parties' original intent. The
     remaining portions will remain in full force and effect. Any failure on the
     part of AiiDAlab to enforce any provision of these Terms of Use will not be
-    considered a waiver of our right to enforce such provision. EPFL rights
-    under this Agreement will survive any termination of these Terms of Use.
+    considered a waiver of our right to enforce such provision. PSI rights under
+    this Agreement will survive any termination of these Terms of Use.
   </p>
 
   <h4>15.4. Nature of Agreement; Amendments; Complete Agreement</h4>
   <p>
-    The Terms of Use constitute a bilateral agreement between you and EPFL for
+    The Terms of Use constitute a bilateral agreement between you and PSI for
     your use of the Website and/or the Services. These Terms of Use may only be
     modified by a written amendment signed by an authorized representative of
-    EPFL, or by the posting by EPFL of a revised version in accordance with
+    PSI, or by the posting by PSI of a revised version in accordance with
     Section 13.
   </p>
   <p>
     These Terms of Use, together with the AiiDAlab Privacy Policy, represent the
-    complete and exclusive statement of the agreement between you and EPFL on
-    the subject matter herein. Such agreement supersedes any proposal or prior
-    agreement oral or written, and any other communications between you and EPFL
+    complete and exclusive statement of the agreement between you and PSI on the
+    subject matter herein. Such agreement supersedes any proposal or prior
+    agreement oral or written, and any other communications between you and PSI
     or AiiDAlab relating to the subject matter of these terms including any
     confidentiality or nondisclosure agreements.
   </p>
@@ -671,7 +659,7 @@ located on ould.org -->. Your account will be then activated. You hereby warrant
     >&rdquo; by GitHub Inc. used under the
     <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank"
       >Creative Common Attribution License</a
-    >. This work is licensed under Creative Common Attribution License by Ecole
-    Polytechnique F&eacute;d&eacute;rale de Lausanne.
+    >. This work is licensed under Creative Common Attribution License by Paul
+    Scherrer Institute.
   </p>
 </div>


### PR DESCRIPTION
Couple of were missing from the last pr (#12)

* replacing EPFL with PSI in terms & privacy policy
* making both policies, specific to Materials Cloud deployment, and moving the links to the corresponding deployment box